### PR TITLE
Demographic data and iso3166 lookup

### DIFF
--- a/schema/montagu-db.xml
+++ b/schema/montagu-db.xml
@@ -802,9 +802,9 @@
 <part>id</part>
 </key>
 </table>
-<table x="282" y="1132" name="gender">
+<table x="281" y="1048" name="gender">
 <row name="id" null="0" autoincrement="0">
-<datatype>TEXT</datatype>
+<datatype>INTEGER</datatype>
 </row>
 <row name="name" null="0" autoincrement="0">
 <datatype>VARCHAR(6)</datatype>
@@ -833,7 +833,7 @@
 </row>
 <row name="age_to" null="1" autoincrement="0">
 <datatype>INTEGER</datatype>
-</row>
+<default>NULL</default></row>
 <row name="value" null="0" autoincrement="0">
 <datatype>DECIMAL</datatype>
 </row>
@@ -848,19 +848,19 @@
 <default>NULL</default><relation table="projection_variant" row="id" />
 </row>
 <row name="gender" null="0" autoincrement="0">
-<datatype>TEXT</datatype>
+<datatype>INTEGER</datatype>
 <relation table="gender" row="id" />
 </row>
 <row name="country" null="0" autoincrement="0">
-<datatype>TEXT</datatype>
-<relation table="country" row="id" />
+<datatype>INTEGER</datatype>
+<relation table="iso3166" row="id" />
 </row>
 <row name="source" null="0" autoincrement="0">
 <datatype>TEXT</datatype>
 <relation table="source" row="id" />
 </row>
 <row name="demographic_statistic_type" null="0" autoincrement="0">
-<datatype>TEXT</datatype>
+<datatype>INTEGER</datatype>
 <relation table="demographic_statistic_type" row="id" />
 </row>
 <key type="PRIMARY" name="">
@@ -869,7 +869,7 @@
 </table>
 <table x="53" y="1241" name="demographic_statistic_type">
 <row name="id" null="0" autoincrement="0">
-<datatype>TEXT</datatype>
+<datatype>INTEGER</datatype>
 </row>
 <row name="age_interpretation" null="0" autoincrement="0">
 <datatype>TEXT</datatype>
@@ -907,5 +907,24 @@
 <key type="PRIMARY" name="">
 <part>id</part>
 </key>
+</table>
+<table x="321" y="1234" name="iso3166">
+<row name="id" null="1" autoincrement="0">
+<datatype>INTEGER</datatype>
+<default>NULL</default></row>
+<row name="c3" null="0" autoincrement="0">
+<datatype>VARCHAR(3)</datatype>
+<default>'NULL'</default><relation table="country" row="id" />
+</row>
+<row name="name" null="0" autoincrement="0">
+<datatype>VARCHAR(255)</datatype>
+<default>'NULL'</default></row>
+<key type="PRIMARY" name="">
+<part>id</part>
+</key>
+<key type="INDEX" name="">
+<part>c3</part>
+</key>
+<comment>Country lookup table</comment>
 </table>
 </sql>


### PR DESCRIPTION
The UNWPP data uses numerical id, whereas the country table uses 3-digit alpha ID. I've created the iso3166 table in the db which translates between them, so "country" in the unwpp data maps to "id" in iso3166, and the matching c3 maps to the country id.

There is one issue: UNWPP in their manifold wisdom have used 830 Channel Islands, which is not part of ISO 3166-1, and has no matching 3-digit alpha code. (Ideally they should have separated into 831 and 832, GGY and JEY, Guernsey and Jersey. 

For now, I have made a dirty hack and put 830 Channel Islands in iso3166 as code ZZZ.