### PR TITLE
Drop unwanted touchstone column

### DIFF
--- a/migrations/sql/V2017.10.17.1416__RemoveTouchstoneDDset.sql
+++ b/migrations/sql/V2017.10.17.1416__RemoveTouchstoneDDset.sql
@@ -1,0 +1,5 @@
+/* i662 erroneously added touchstone->touchstone_demographic_dataset */
+/* Don't want this - we only need touchstone_demographic_dataset->touchstone - which we have. */
+/* All data in this field will be NA, so removing it should be no problem. */
+
+ALTER TABLE touchstone DROP COLUMN touchstone_demographic_dataset;


### PR DESCRIPTION
Issue i815 - 
touchstone->touchstone_demographic_dataset was erroneously added in i662.

Removing it should have no consequences;
touchstone_demographic_dataset->touchstone is what we want, and we have it.

