### PR TITLE
i1385:  Add role for stochastic ingest tool 

### DIFF
--- a/migrations/sql/V2018.01.24.17.02__AddEstimateWriterRole.sql
+++ b/migrations/sql/V2018.01.24.17.02__AddEstimateWriterRole.sql
@@ -1,14 +1,16 @@
 DO $$
 	declare role_id int;
-
+begin
 	insert into role (name, scope_prefix, description)
 	values (
 		'estimates-writer', 
 		null, 
 		'Upload burden estimates to ANY group (useful for stochastic ingest tool)'
 	)
-	returning id as role_id;
+	returning id into role_id;
 
+	-- All users get estimates.read and responsibilities.read, so we don't need to 
+	-- add these here
 	insert into role_permission values (role_id, 'estimates.read-unfinished');
 	insert into role_permission values (role_id, 'estimates.write');
-$$;
+end $$;

--- a/migrations/sql/V2018.01.24.17.02__AddEstimateWriterRole.sql
+++ b/migrations/sql/V2018.01.24.17.02__AddEstimateWriterRole.sql
@@ -1,0 +1,14 @@
+DO $$
+	declare role_id int;
+
+	insert into role (name, scope_prefix, description)
+	values (
+		'estimates-writer', 
+		null, 
+		'Upload burden estimates to ANY group (useful for stochastic ingest tool)'
+	)
+	returning id into role_id;
+
+	insert into role_permission values (role_id, 'estimates.read-unfinished');
+	insert into role_permission values (role_id, 'estimates.write');
+$$;

--- a/migrations/sql/V2018.01.24.17.02__AddEstimateWriterRole.sql
+++ b/migrations/sql/V2018.01.24.17.02__AddEstimateWriterRole.sql
@@ -7,7 +7,7 @@ DO $$
 		null, 
 		'Upload burden estimates to ANY group (useful for stochastic ingest tool)'
 	)
-	returning id into role_id;
+	returning id as role_id;
 
 	insert into role_permission values (role_id, 'estimates.read-unfinished');
 	insert into role_permission values (role_id, 'estimates.write');

--- a/scripts/test-migrate.sh
+++ b/scripts/test-migrate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+DB_CONTAINER=db
+DB_ANNEX_CONTAINER=db_annex
+DB_IMAGE=montagu_db
+MIGRATE_IMAGE=montagu_migrate
+NETWORK=db_nw
+
+docker build --tag $DB_IMAGE .
+docker build --tag $MIGRATE_IMAGE -f migrations/Dockerfile .
+
+function cleanup {
+    set +e
+    docker stop $DB_CONTAINER $DB_ANNEX_CONTAINER
+    docker network rm $NETWORK
+}
+trap cleanup EXIT
+
+docker network create $NETWORK
+
+docker run --rm --network=$NETWORK -d --name $DB_CONTAINER $DB_IMAGE
+docker run --rm --network=$NETWORK -d --name $DB_ANNEX_CONTAINER $DB_IMAGE
+
+# Wait for things to become responsive
+docker exec $DB_CONTAINER montagu-wait.sh
+docker exec $DB_ANNEX_CONTAINER montagu-wait.sh
+
+# Do the migrations
+docker run --rm --network=$NETWORK $MIGRATE_IMAGE -configFile=conf/flyway-annex.conf migrate
+docker run --rm --network=$NETWORK $MIGRATE_IMAGE


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1385

I realised while working on this that we no longer had a way of testing migrations location: the `teamcity-migrate.sh` script now uses the common `start.sh` script, which is shared across multiple repos. This script insists on running a migrate image from our registry: it can't be a locally build one.

To solve this, I wrote a new `test-migrate.sh` script which duplicates some code from `start.sh`. I think this is preferable to making `start.sh` more configurable, as it's already at a level of complexity that almost warrants a python program. It's fine if `test-migrate.sh` falls behind a bit, and occasionally fails and needs updating when you run it: It's only used by developers during development, and TeamCity still exists as the ultimate authority on whether a migration is valid.