### PR TITLE
Create tables to hold new gavi metadata

### DIFF
--- a/migrations/sql/V2018.01.26.1000__AddGaviCountryStatus.sql
+++ b/migrations/sql/V2018.01.26.1000__AddGaviCountryStatus.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "gavi_eligibility_status" (
+  "id" INTEGER,
+  "name" TEXT,
+  PRIMARY KEY ("id")
+);
+
+CREATE TABLE "gavi_eligibility" (
+  "id"  SERIAL,
+  "touchstone" TEXT,
+  "country" TEXT,
+  "year" INTEGER,
+  "status" INTEGER,
+  PRIMARY KEY ("id"),
+  FOREIGN KEY (touchstone) REFERENCES touchstone(id),
+  FOREIGN KEY (country) REFERENCES country(id),
+  FOREIGN KEY (status) REFERENCES gavi_eligibility_status(id)
+);
+
+INSERT INTO gavi_eligibility_status (id, name) VALUES
+  (0, 'Pre-Gavi eligible'),
+  (1, 'Currently eligible'),
+  (2, 'Transitioned'),
+  (3, 'Never eligible - MIC'),
+  (4, 'Never eligible - HIC');

--- a/migrations/sql/V2018.01.26.1000__AddGaviCountryStatus.sql
+++ b/migrations/sql/V2018.01.26.1000__AddGaviCountryStatus.sql
@@ -13,7 +13,8 @@ CREATE TABLE "gavi_eligibility" (
   PRIMARY KEY ("id"),
   FOREIGN KEY (touchstone) REFERENCES touchstone(id),
   FOREIGN KEY (country) REFERENCES country(id),
-  FOREIGN KEY (status) REFERENCES gavi_eligibility_status(id)
+  FOREIGN KEY (status) REFERENCES gavi_eligibility_status(id),
+  UNIQUE ("touchstone", "country", "year")
 );
 
 INSERT INTO gavi_eligibility_status (id, name) VALUES


### PR DESCRIPTION
This adds two new tables - the data are expected to change over time so they're linked against touchstone (in the import PR for montagu-data the data that comes in will be identical but it's not large - about 10K rows per touchstone). The enum entries are from GAVI themselves so they do not conform to our text keys.  I could add a third column to the enum table with that, with some minor tweaks to the data import

