### PR TITLE
Add user group tables

### DIFF
--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -25,4 +25,4 @@ VALUES ('GAVI', 'All members of GAVI'),
 INSERT INTO user_report_user_group (username, user_group)
   SELECT (username, 'Modellers')
   FROM user_role
-  WHERE role = 'member';
+  WHERE role = 9;

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -1,16 +1,17 @@
 CREATE TABLE user_group (
+  id TEXT NOT NULL,
   name        TEXT NOT NULL,
   description TEXT NULL,
-  PRIMARY KEY (name)
+  PRIMARY KEY (id)
 );
 
-CREATE TABLE user_group_user (
+CREATE TABLE user_group_membership (
   username   TEXT NOT NULL,
   user_group TEXT NOT NULL,
   PRIMARY KEY (username, user_group)
 );
 
-ALTER TABLE user_group_user
+ALTER TABLE user_group_membership
   ADD FOREIGN KEY (username) REFERENCES app_user (username);
 ALTER TABLE user_group_user
   ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
@@ -26,25 +27,9 @@ ALTER TABLE user_group_role ADD FOREIGN KEY (user_group) REFERENCES user_group (
 ALTER TABLE user_group_role ADD FOREIGN KEY (role) REFERENCES role (id);
 
 -- create standard groups
-INSERT INTO user_group (name, description)
-VALUES ('GAVI', 'All members of GAVI'),
-  ('Gates', 'All members of the Gates foundation'),
-  ('Modellers', 'Members of modelling groups'),
-  ('Secretariat', 'Members of the consortium secretariat');
+INSERT INTO user_group (id, name, description)
+VALUES ('gavi', 'GAVI', 'All members of GAVI'),
+  ('gates', 'Gates', 'All members of the Gates foundation'),
+  ('modellers', 'Modellers', 'Members of modelling groups'),
+  ('secretariat', 'Secretariat', 'Members of the consortium secretariat');
 
--- for each user create group of same name
-INSERT INTO user_group (name, description)
-  SELECT username, 'Individual user group'
-  FROM app_user;
-
--- migrate all existent role mappings to new table
-INSERT INTO user_group_role (user_group, role, scope_id)
-  SELECT user_group_user.user_group, user_role.role, user_role.scope_id
-  FROM user_role join user_group_user
-  ON user_group_user.username = user_role.username;
-
--- insert all modellers into Modellers group
-INSERT INTO user_group_user (username, user_group)
-  SELECT username, 'Modellers'
-  FROM user_role
-  WHERE role = 9;

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -1,33 +1,40 @@
-CREATE TABLE report_user_group (
+CREATE TABLE user_group (
   "name"        TEXT NOT NULL,
   "description" TEXT NULL,
   PRIMARY KEY ("name")
 );
 
-CREATE TABLE user_report_user_group (
+CREATE TABLE user_group_user (
   username   TEXT NOT NULL,
   user_group TEXT NOT NULL,
   PRIMARY KEY (username, user_group)
 );
 
-ALTER TABLE user_report_user_group
+CREATE TABLE user_group_role (
+"user_group" TEXT NOT NULL ,
+"role" INTEGER ,
+"scope_id" TEXT NOT NULL ,
+PRIMARY KEY ("user_group", "role", "scope_id")
+);
+
+ALTER TABLE user_group_user
   ADD FOREIGN KEY (username) REFERENCES app_user (username);
-ALTER TABLE user_report_user_group
+ALTER TABLE user_group_user
   ADD FOREIGN KEY (user_group) REFERENCES report_user_group (name);
 
-INSERT INTO report_user_group (name, description)
+INSERT INTO user_group (name, description)
 VALUES ('GAVI', 'All members of GAVI'),
   ('Gates', 'All members of the Gates foundation'),
   ('Modellers', 'Members of modelling groups'),
   ('Secretariat', 'Members of the consortium secretariat');
 
 -- for each user create group of same name
-INSERT INTO report_user_group (name, description)
+INSERT INTO user_group (name, description)
   SELECT username, 'Individual user group'
   FROM app_user;
 
 -- insert all modellers into Modellers group
-INSERT INTO user_report_user_group (username, user_group)
+INSERT INTO user_group_user (username, user_group)
   SELECT username, 'Modellers'
   FROM user_role
   WHERE role = 9;

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -14,7 +14,7 @@ CREATE TABLE user_group_membership (
 ALTER TABLE user_group_membership
   ADD FOREIGN KEY (username) REFERENCES app_user (username);
 ALTER TABLE user_group_membership
-  ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
+  ADD FOREIGN KEY (user_group) REFERENCES user_group (id);
 
 CREATE TABLE user_group_role (
 user_group TEXT NOT NULL ,
@@ -23,7 +23,7 @@ scope_id TEXT NOT NULL ,
 PRIMARY KEY (user_group, role, scope_id)
 );
 
-ALTER TABLE user_group_role ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
+ALTER TABLE user_group_role ADD FOREIGN KEY (user_group) REFERENCES user_group (id);
 ALTER TABLE user_group_role ADD FOREIGN KEY (role) REFERENCES role (id);
 
 -- create standard groups

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -20,7 +20,7 @@ PRIMARY KEY ("user_group", "role", "scope_id")
 ALTER TABLE user_group_user
   ADD FOREIGN KEY (username) REFERENCES app_user (username);
 ALTER TABLE user_group_user
-  ADD FOREIGN KEY (user_group) REFERENCES report_user_group (name);
+  ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
 
 INSERT INTO user_group (name, description)
 VALUES ('GAVI', 'All members of GAVI'),

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -23,6 +23,6 @@ VALUES ('GAVI', 'All members of GAVI'),
 
 -- insert all modellers into Modellers group
 INSERT INTO user_report_user_group (username, user_group)
-  SELECT (username, 'Modellers')
+  SELECT username, 'Modellers'
   FROM user_role
   WHERE role = 9;

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -21,7 +21,7 @@ VALUES ('GAVI', 'All members of GAVI'),
   ('Modellers', 'Members of modelling groups'),
   ('Secretariat', 'Members of the consortium secretariat');
 
--- insert all modellers into modelling group
+-- insert all modellers into Modellers group
 INSERT INTO user_report_user_group (username, user_group)
   SELECT (username, 'Modellers')
   FROM user_role

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -10,6 +10,11 @@ CREATE TABLE user_group_user (
   PRIMARY KEY (username, user_group)
 );
 
+ALTER TABLE user_group_user
+  ADD FOREIGN KEY (username) REFERENCES app_user (username);
+ALTER TABLE user_group_user
+  ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
+
 CREATE TABLE user_group_role (
 "user_group" TEXT NOT NULL ,
 "role" INTEGER ,
@@ -17,11 +22,10 @@ CREATE TABLE user_group_role (
 PRIMARY KEY ("user_group", "role", "scope_id")
 );
 
-ALTER TABLE user_group_user
-  ADD FOREIGN KEY (username) REFERENCES app_user (username);
-ALTER TABLE user_group_user
-  ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
+ALTER TABLE "user_group_role" ADD FOREIGN KEY ("user_group") REFERENCES "user_group" ("name");
+ALTER TABLE "user_group_role" ADD FOREIGN KEY ("role") REFERENCES "role" ("id");
 
+-- create standard groups
 INSERT INTO user_group (name, description)
 VALUES ('GAVI', 'All members of GAVI'),
   ('Gates', 'All members of the Gates foundation'),
@@ -32,6 +36,12 @@ VALUES ('GAVI', 'All members of GAVI'),
 INSERT INTO user_group (name, description)
   SELECT username, 'Individual user group'
   FROM app_user;
+
+-- migrate all existent role mappings to new table
+INSERT INTO user_group_role (user_group, role, scope_id)
+  SELECT user_group_user.user_group, user_role.role, user_role.scope_id
+  FROM user_role join user_group_user
+  on user_group_user.username = user_role.username
 
 -- insert all modellers into Modellers group
 INSERT INTO user_group_user (username, user_group)

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -21,6 +21,11 @@ VALUES ('GAVI', 'All members of GAVI'),
   ('Modellers', 'Members of modelling groups'),
   ('Secretariat', 'Members of the consortium secretariat');
 
+-- for each user create group of same name
+INSERT INTO report_user_group (name, description)
+  SELECT username, 'Individual user group'
+  FROM app_user;
+
 -- insert all modellers into Modellers group
 INSERT INTO user_report_user_group (username, user_group)
   SELECT username, 'Modellers'

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -13,7 +13,7 @@ CREATE TABLE user_group_membership (
 
 ALTER TABLE user_group_membership
   ADD FOREIGN KEY (username) REFERENCES app_user (username);
-ALTER TABLE user_group_user
+ALTER TABLE user_group_membership
   ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
 
 CREATE TABLE user_group_role (

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -1,0 +1,28 @@
+CREATE TABLE report_user_group (
+  "name"        TEXT NOT NULL,
+  "description" TEXT NULL,
+  PRIMARY KEY ("name")
+);
+
+CREATE TABLE user_report_user_group (
+  username   TEXT NOT NULL,
+  user_group TEXT NOT NULL,
+  PRIMARY KEY (username, user_group)
+);
+
+ALTER TABLE user_report_user_group
+  ADD FOREIGN KEY (username) REFERENCES app_user (username);
+ALTER TABLE user_report_user_group
+  ADD FOREIGN KEY (user_group) REFERENCES report_user_group (name);
+
+INSERT INTO report_user_group (name, description)
+VALUES ('GAVI', 'All members of GAVI'),
+  ('Gates', 'All members of the Gates foundation'),
+  ('Modellers', 'Members of modelling groups'),
+  ('Secretariat', 'Members of the consortium secretariat');
+
+-- insert all modellers into modelling group
+INSERT INTO user_report_user_group (username, user_group)
+  SELECT (username, 'Modellers')
+  FROM user_role
+  WHERE role = 'member';

--- a/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
+++ b/migrations/sql/V2018.02.20.1505__AddUserGroup.sql
@@ -1,7 +1,7 @@
 CREATE TABLE user_group (
-  "name"        TEXT NOT NULL,
-  "description" TEXT NULL,
-  PRIMARY KEY ("name")
+  name        TEXT NOT NULL,
+  description TEXT NULL,
+  PRIMARY KEY (name)
 );
 
 CREATE TABLE user_group_user (
@@ -16,14 +16,14 @@ ALTER TABLE user_group_user
   ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
 
 CREATE TABLE user_group_role (
-"user_group" TEXT NOT NULL ,
-"role" INTEGER ,
-"scope_id" TEXT NOT NULL ,
-PRIMARY KEY ("user_group", "role", "scope_id")
+user_group TEXT NOT NULL ,
+role INTEGER ,
+scope_id TEXT NOT NULL ,
+PRIMARY KEY (user_group, role, scope_id)
 );
 
-ALTER TABLE "user_group_role" ADD FOREIGN KEY ("user_group") REFERENCES "user_group" ("name");
-ALTER TABLE "user_group_role" ADD FOREIGN KEY ("role") REFERENCES "role" ("id");
+ALTER TABLE user_group_role ADD FOREIGN KEY (user_group) REFERENCES user_group (name);
+ALTER TABLE user_group_role ADD FOREIGN KEY (role) REFERENCES role (id);
 
 -- create standard groups
 INSERT INTO user_group (name, description)
@@ -41,7 +41,7 @@ INSERT INTO user_group (name, description)
 INSERT INTO user_group_role (user_group, role, scope_id)
   SELECT user_group_user.user_group, user_role.role, user_role.scope_id
   FROM user_role join user_group_user
-  on user_group_user.username = user_role.username
+  ON user_group_user.username = user_role.username;
 
 -- insert all modellers into Modellers group
 INSERT INTO user_group_user (username, user_group)


### PR DESCRIPTION
3 new tables. `user_group` and `user_group_user`  are slightly confusing - can you think of better names!?

This migration also creates a user group for each user, unix style, creates other standard groups, and inserts all members of a modelling group into the user group 'modellers'.