### PR TITLE
i1676: Fix pip installation

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get update && \
                 python3-setuptools \
                 wget
 
-RUN pip3 install --upgrade pip &&\
-        pip3 install docopt
+RUN pip3 install docopt
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
         apt-key add - && \


### PR DESCRIPTION
This results in a really cryptic non-error error:

```
Collecting docopt
  Downloading https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
Building wheels for collected packages: docopt
  Running setup.py bdist_wheel for docopt ... error
  Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-elw77ng_/docopt/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpynbbc1sdpip-wheel- --python-tag cp35:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------
  Failed building wheel for docopt
  Running setup.py clean for docopt
Failed to build docopt
Installing collected packages: docopt
  Running setup.py install for docopt ... done
Successfully installed docopt-0.6.2
You are using pip version 8.1.1, however version 10.0.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

but despite that seems to work.  The pip upgrade I think used to fix this but
that is now broken.