### PR TITLE
i1431 Drop burden_estimate.id

### DIFF
--- a/migrations/sql-annex/V2018.04.23.1339__BurdenEstimateStochastic_RemoveArtificialKey.sql
+++ b/migrations/sql-annex/V2018.04.23.1339__BurdenEstimateStochastic_RemoveArtificialKey.sql
@@ -1,0 +1,9 @@
+ALTER TABLE burden_estimate_stochastic
+  DROP COLUMN id,
+  DROP CONSTRAINT burden_estimate_stochastic_unique,
+  ADD PRIMARY KEY (burden_estimate_set,
+                   model_run,
+                   country,
+                   year,
+                   age,
+                   burden_outcome);

--- a/migrations/sql/V2018.04.23.1101__BurdenEstimate_RemoveArtificialKey.sql
+++ b/migrations/sql/V2018.04.23.1101__BurdenEstimate_RemoveArtificialKey.sql
@@ -1,8 +1,8 @@
 ALTER TABLE burden_estimate
   DROP COLUMN id,
+  DROP CONSTRAINT burden_estimate_unique,
   ADD PRIMARY KEY (burden_estimate_set,
-                   country,
-                   year,
-                   age,
-                   burden_outcome),
-  DROP CONSTRAINT burden_estimate_unique;
+                      country,
+                      year,
+                      age,
+                      burden_outcome);

--- a/migrations/sql/V2018.04.23.1101__BurdenEstimate_RemoveArtificialKey.sql
+++ b/migrations/sql/V2018.04.23.1101__BurdenEstimate_RemoveArtificialKey.sql
@@ -1,0 +1,8 @@
+ALTER TABLE burden_estimate
+  DROP COLUMN id,
+  ADD PRIMARY KEY (burden_estimate_set,
+                   country,
+                   year,
+                   age,
+                   burden_outcome),
+  DROP CONSTRAINT burden_estimate_unique;

--- a/migrations/sql/V2018.04.23.1101__ChangeBurdenEstimateIdToBigSerial.sql
+++ b/migrations/sql/V2018.04.23.1101__ChangeBurdenEstimateIdToBigSerial.sql
@@ -1,4 +1,0 @@
-ALTER TABLE burden_estimate
-  DROP COLUMN id,
-  ADD COLUMN id BIGSERIAL NOT NULL,
-  ADD PRIMARY KEY ("id");

--- a/migrations/sql/V2018.04.23.1101__ChangeBurdenEstimateIdToBigSerial.sql
+++ b/migrations/sql/V2018.04.23.1101__ChangeBurdenEstimateIdToBigSerial.sql
@@ -1,0 +1,4 @@
+ALTER TABLE burden_estimate
+  DROP COLUMN id,
+  ADD COLUMN id BIGSERIAL NOT NULL,
+  ADD PRIMARY KEY ("id");


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1431

Changed this migration to drop the artificial primary key and add a natural one.

I can't see anyway of directly converting the existing unique constraint to a primary key, sadly, so this will take a while.