### PR TITLE
I1710 - nightly backups in barman

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && \
                 python3-setuptools \
                 wget
 
+RUN service cron start
+
 RUN pip3 install docopt
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -22,6 +22,7 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
 VOLUME /var/lib/barman
 VOLUME /var/log/barman
 VOLUME /recover
+VOLUME /nightly
 
 COPY etc /etc
 COPY bin /usr/local/bin

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -10,8 +10,6 @@ RUN apt-get update && \
                 python3-setuptools \
                 wget
 
-RUN service cron start
-
 RUN pip3 install docopt
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:16.04
 # key from the postgres deb repo
 RUN apt-get update && \
         apt-get install -y --no-install-recommends \
+                cron \
                 python3-pip \
                 python3-setuptools \
                 wget

--- a/backup/README.md
+++ b/backup/README.md
@@ -144,3 +144,15 @@ If we copy files around, using scp with `-o "Compression no"` can speed things u
 1. Stop montagu so that the db stops, but do not remove the data volume
 2. Rsync from the restore into the container with appropriate `--delete` flags set: this will hopefully reduce copying around too much
 3. Start up montagu!
+
+## Testing
+
+Copy `testing/montagu-deploy.json` into your `montagu/src` directory - this creates a minimal montagu deployment that supports streaming replication.
+
+Run:
+
+```
+./barman-montagu setup --pull-image localhost
+```
+
+(you may want to specify `--image-tag` too to run the branch you're working on).

--- a/backup/README.md
+++ b/backup/README.md
@@ -86,12 +86,14 @@ To dump out the latest copy of the database to recover from:
 You will then need to clone the contents of the `barman_recover` volume into a suitable place for the Postgres server to read from.
 
 
-Every night a snapshot of the database is written out to the `barman_nightly` volume. You can trigger this at other times by running
+Every night a snapshot of the database can be written out to the `barman_nightly` volume, by running
 
 
 ```
 ./barman-montagu update-nightly
 ```
+
+This should be arranged to run on your host machine.
 
 For a manual dump, prefer the `barman-montagu recover` which writes to the `barman_recover` volume.
 
@@ -115,7 +117,7 @@ The barman container must be able to reach the montagu-db container over the net
 1. `barman_data` (at `/var/lib/barman`) is the one that holds the backup - this should itself be backed up
 2. `barman_logs` (at `/var/log/barman`) is used to persist logs
 3. `barman_recover` (at `/recover`) holds a manual recovery location - ensure that this is empty before restoring into it
-4. `barman_nightly` (at `/nightly`) holds an automatic nightly recovery
+4. `barman_nightly` (at `/nightly`) holds a periodic recovery
 
 Barman needs to know the hostname, port, database name, two user names and two passwords.  Defaults for these are set in [etc/barman.d.in/montagu.json](etc/barman.d.in/montagu.json) but can be overridden by passing environment variables to the container in the form `BARMAN_MONTAGU_<key>` where `<key>` is one of the entries from the json, in uppercase (this can be done either with the `-e` flag or `--env-file` argument (e.g., `BARMAN_MONTAGU_PASS_BACKUP`)
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -85,11 +85,15 @@ To dump out the latest copy of the database to recover from:
 
 You will then need to clone the contents of the `barman_recover` volume into a suitable place for the Postgres server to read from.
 
-There is a nightly recovery - you can trigger this at other times by running
+
+Every night a snapshot of the database is written out to the `barman_nightly` volume. You can trigger this at other times by running
+
 
 ```
 ./barman-montagu update-nightly
 ```
+
+For a manual dump, prefer the `barman-montagu recover` which writes to the `barman_recover` volume.
 
 To remove all traces of barman (the container and the volumes), use:
 
@@ -111,7 +115,7 @@ The barman container must be able to reach the montagu-db container over the net
 1. `barman_data` (at `/var/lib/barman`) is the one that holds the backup - this should itself be backed up
 2. `barman_logs` (at `/var/log/barman`) is used to persist logs
 3. `barman_recover` (at `/recover`) holds a manual recovery location - ensure that this is empty before restoring into it
-4. `barman_nightly` (at `/nightly`) holds an automatic nightly backup
+4. `barman_nightly` (at `/nightly`) holds an automatic nightly recovery
 
 Barman needs to know the hostname, port, database name, two user names and two passwords.  Defaults for these are set in [etc/barman.d.in/montagu.json](etc/barman.d.in/montagu.json) but can be overridden by passing environment variables to the container in the form `BARMAN_MONTAGU_<key>` where `<key>` is one of the entries from the json, in uppercase (this can be done either with the `-e` flag or `--env-file` argument (e.g., `BARMAN_MONTAGU_PASS_BACKUP`)
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -12,10 +12,18 @@ cd montagu-db-backup/backup
 pip3 install -r requirements.txt
 ```
 
-Then interact with the barman container the `./barman-montagu` command:
+Then install the command with
 
 ```
-$ ./barman-montagu --help
+sudo ./install
+```
+
+which sets up a `barman-montagu` command that can be used from anywhere on the computer that refers to the configuration in *this* directory (you can also use `./barman-montagu` and avoid installing).
+
+Then you can interact with the barman container the `barman-montagu` command:
+
+```
+$ barman-montagu --help
 Set up and use barman (Postgres streaming backup) for montagu
 
 Usage:
@@ -39,13 +47,13 @@ These commands create and pass through to the `barman` process in a long running
 To set up barman:
 
 ```
-./barman-montagu setup --pull-image production.montagu.dide.ic.ac.uk
+barman-montagu setup --pull-image production.montagu.dide.ic.ac.uk
 ```
 
 Or, for local testing you would want:
 
 ```
-./barman-montagu setup --pull-image localhost
+barman-montagu setup --pull-image localhost
 ```
 
 Currently the port 5432 is assumed.
@@ -53,26 +61,26 @@ Currently the port 5432 is assumed.
 To see a set of status information run
 
 ```
-./barman-montagu status
+barman-montagu status
 ```
 
 To interact with barman directly, either do `docker exec barman-montagu barman ...` or use
 
 ```
 
-./barman-montagu barman -- --help
+barman-montagu barman -- --help
 ```
 
 (the `--` is often optional but disambiguates arguments to `barman-montagu` and for barman).  For example listing files in the most recent backup might look like:
 
 ```
-./barman-montagu barman list-files montagu latest
+barman-montagu barman list-files montagu latest
 ```
 
 or getting information about the latest backup:
 
 ```
-./barman-montagu barman show-backup montagu latest
+barman-montagu barman show-backup montagu latest
 ```
 
 (see [the `barman` docs](http://docs.pgbarman.org/release/2.0) for more commands).
@@ -80,7 +88,7 @@ or getting information about the latest backup:
 To dump out the latest copy of the database to recover from:
 
 ```
-./barman-montagu recover --wipe-first
+barman-montagu recover --wipe-first
 ```
 
 You will then need to clone the contents of the `barman_recover` volume into a suitable place for the Postgres server to read from.
@@ -90,7 +98,7 @@ Every night a snapshot of the database can be written out to the `barman_nightly
 
 
 ```
-./barman-montagu update-nightly
+barman-montagu update-nightly
 ```
 
 This should be arranged to run on your host machine.
@@ -100,7 +108,7 @@ For a manual dump, prefer the `barman-montagu recover` which writes to the `barm
 To remove all traces of barman (the container and the volumes), use:
 
 ```
-./barman-montagu destroy
+barman-montagu destroy
 ```
 
 The `barman-montagu` script does not depend on its location and can be moved to a position within `$PATH`.
@@ -158,7 +166,7 @@ Copy `testing/montagu-deploy.json` into your `montagu/src` directory - this crea
 Run:
 
 ```
-./barman-montagu setup --pull-image localhost
+barman-montagu setup --pull-image localhost
 ```
 
 (you may want to specify `--image-tag` too to run the branch you're working on).

--- a/backup/README.md
+++ b/backup/README.md
@@ -94,7 +94,7 @@ barman-montagu recover --wipe-first
 You will then need to clone the contents of the `barman_recover` volume into a suitable place for the Postgres server to read from.
 
 
-Every night a snapshot of the database can be written out to the `barman_nightly` volume, by running
+Every night a snapshot of the database can be written out to the `montagu_db_volume` volume, by running
 
 
 ```
@@ -125,7 +125,7 @@ The barman container must be able to reach the montagu-db container over the net
 1. `barman_data` (at `/var/lib/barman`) is the one that holds the backup - this should itself be backed up
 2. `barman_logs` (at `/var/log/barman`) is used to persist logs
 3. `barman_recover` (at `/recover`) holds a manual recovery location - ensure that this is empty before restoring into it
-4. `barman_nightly` (at `/nightly`) holds a periodic recovery
+4. `montagu_db_volume` (at `/nightly`) holds a periodic recovery
 
 Barman needs to know the hostname, port, database name, two user names and two passwords.  Defaults for these are set in [etc/barman.d.in/montagu.json](etc/barman.d.in/montagu.json) but can be overridden by passing environment variables to the container in the form `BARMAN_MONTAGU_<key>` where `<key>` is one of the entries from the json, in uppercase (this can be done either with the `-e` flag or `--env-file` argument (e.g., `BARMAN_MONTAGU_PASS_BACKUP`)
 

--- a/backup/barman-montagu
+++ b/backup/barman-montagu
@@ -32,10 +32,12 @@ BARMAN_CONTAINER = 'barman-montagu'
 # but the 'path' element corresponds to a path within the container
 # and are assumed by either barman (for data and logs) or us (for
 # recover).
-BARMAN_VOLUMES = {'data': {'volume': 'barman_data', 'path': '/var/lib/barman'},
-                  'libs': {'volume': 'barman_logs', 'path': '/var/log/barman'},
-                  'recover': {'volume': 'barman_recover', 'path': '/recover'},
-                  'nightly': {'volume': 'barman_nightly', 'path': '/nightly'}}
+BARMAN_VOLUMES = {
+    'data': {'volume': 'barman_data', 'path': '/var/lib/barman'},
+    'libs': {'volume': 'barman_logs', 'path': '/var/log/barman'},
+    'recover': {'volume': 'barman_recover', 'path': '/recover'},
+    'nightly': {'volume': 'montagu_db_volume', 'path': '/nightly'}
+}
 DATABASE_NAME = "montagu"
 DOCKER_REGISTRY = "docker.montagu.dide.ic.ac.uk:5000"
 DOCKER_IMAGE = "montagu-barman"

--- a/backup/barman-montagu
+++ b/backup/barman-montagu
@@ -6,11 +6,11 @@ Usage:
   barman-montagu status
   barman-montagu barman [--] [<args>...]
   barman-montagu recover [--wipe-first] [<backup-id>]
+  barman-montagu recover-nightly
   barman-montagu wipe-recover
   barman-montagu destroy
 
 Options:
-  --configure-cron          Configure a once-a-minute cron job
   --password-group=<group>  Password group [default: production]
   --image-tag=<tag>         Barman image tag [default: master]
   --pull-image              Pull image before running?
@@ -21,7 +21,6 @@ import os
 import socket
 import subprocess
 
-import crontab
 import docker
 import docopt
 import hvac
@@ -35,25 +34,21 @@ BARMAN_CONTAINER = 'barman-montagu'
 # recover).
 BARMAN_VOLUMES = {'data': {'volume': 'barman_data', 'path': '/var/lib/barman'},
                   'libs': {'volume': 'barman_logs', 'path': '/var/log/barman'},
-                  'recover': {'volume': 'barman_recover', 'path': '/recover'}}
+                  'recover': {'volume': 'barman_recover', 'path': '/recover'},
+                  'nightly': {'volume': 'barman_nightly', 'path': '/nightly'}}
 DATABASE_NAME = "montagu"
 DOCKER_REGISTRY = "docker.montagu.dide.ic.ac.uk:5000"
 DOCKER_IMAGE = "montagu-barman"
-PATH_CRON = "/etc/cron.d/barman-montagu"
 
 
-def setup(host, password_group, tag, pull, cron, clean_on_error):
+def setup(host, password_group, tag, pull, clean_on_error):
     start_barman(host, password_group, tag, pull, clean_on_error)
-    if cron:
-        configure_cron()
 
 
 def status():
     barman = get_barman_container(error=False)
     if barman:
-        cron_status = "enabled" if os.path.exists(PATH_CRON) else "disabled"
         print("{} is running".format(BARMAN_CONTAINER))
-        print("cron job {}".format(cron_status))
         exec_safely(barman, ["barman", "status", DATABASE_NAME],
                     check=True, stream=True)
     else:
@@ -78,6 +73,13 @@ def recover(id, wipe_first):
         BARMAN_VOLUMES["recover"]['volume']))
 
 
+def recover_nightly():
+    barman = get_barman_container()
+    path = BARMAN_VOLUMES['nightly']['path']
+    exec_safely(["update-nightly", DATABASE_NAME, path],
+                stream=True, check=True)
+
+
 def wipe_recover(barman=None):
     barman = barman or get_barman_container()
     print("Wiping recovery volume '{}'".format(
@@ -86,11 +88,6 @@ def wipe_recover(barman=None):
 
 
 def destroy():
-    if os.path.exists(PATH_CRON):
-        print("Removing cron job")
-        if os.getuid() != 0:
-            raise Exception("Please rerun with sudo to remove cron job")
-        os.remove(PATH_CRON)
     print("Removing barman container and volumes")
     d = docker.client.from_env()
     container_remove(BARMAN_CONTAINER, d)
@@ -135,21 +132,6 @@ def start_barman(host, password_group, tag, pull, clean_on_error):
                     v.remove()
         raise
     return barman
-
-
-def configure_cron():
-    print("Configuring cron")
-    if os.getuid() != 0:
-        raise Exception("Please rerun with sudo to install cron job")
-    command = "docker exec {} barman cron".format(BARMAN_CONTAINER)
-
-    if os.path.exists(PATH_CRON):
-        os.remove(PATH_CRON)
-    cron = crontab.CronTab(user=False)
-    job = cron.new(command=command, comment="Barman backup", user="root")
-    job.minute.every(1)
-    cron.write(PATH_CRON)
-    print("Wrote '{}' - remove this file to stop job".format(PATH_CRON))
 
 
 def vault_client():
@@ -273,8 +255,7 @@ def main():
     args = docopt.docopt(__doc__)
     if args['setup']:
         setup(args['<host>'], args['--password-group'], args['--image-tag'],
-              args['--pull-image'], args['--configure-cron'],
-              not args['--no-clean-on-error'])
+              args['--pull-image'], not args['--no-clean-on-error'])
     elif args['status']:
         status()
     elif args['barman']:
@@ -285,6 +266,8 @@ def main():
         destroy()
     elif args['wipe-recover']:
         wipe_recover()
+    elif args['recover-nightly']:
+        recover_nightly()
     else:
         raise Exception("(this should never happen)")
 

--- a/backup/barman-montagu
+++ b/backup/barman-montagu
@@ -6,7 +6,7 @@ Usage:
   barman-montagu status
   barman-montagu barman [--] [<args>...]
   barman-montagu recover [--wipe-first] [<backup-id>]
-  barman-montagu recover-nightly
+  barman-montagu update-nightly
   barman-montagu wipe-recover
   barman-montagu destroy
 
@@ -73,10 +73,9 @@ def recover(id, wipe_first):
         BARMAN_VOLUMES["recover"]['volume']))
 
 
-def recover_nightly():
+def update_nightly():
     barman = get_barman_container()
-    path = BARMAN_VOLUMES['nightly']['path']
-    exec_safely(["update-nightly", DATABASE_NAME, path],
+    exec_safely(barman, ["update-nightly", DATABASE_NAME],
                 stream=True, check=True)
 
 
@@ -266,8 +265,8 @@ def main():
         destroy()
     elif args['wipe-recover']:
         wipe_recover()
-    elif args['recover-nightly']:
-        recover_nightly()
+    elif args['update-nightly']:
+        update_nightly()
     else:
         raise Exception("(this should never happen)")
 

--- a/backup/bin/setup-barman
+++ b/backup/bin/setup-barman
@@ -30,6 +30,7 @@ def verify(conf):
     for x in conf:
         test_connections(x)
     initial_backup(conf)
+    setup_cron(conf)
 
 
 def write_pgpass(dat):
@@ -111,6 +112,16 @@ def initial_backup(conf):
         subprocess.run(["barman", "backup", nm], check=True)
         print("Checking barman status of {}".format(nm), flush=True)
         subprocess.run(["barman", "check", nm], check=True)
+
+
+def setup_cron(conf):
+    print("Setting up cron jobs", flush=True)
+    cron = """
+* * * * * root barman cron
+0 6 * * * root update-nightly {}
+""".lstrip().format(conf["configuration_name"])
+    with open("/etc/cron.d/barman", 'w') as f:
+        f.write(cron)
 
 
 # This seems a bit flakey to archive but usually runs just fine the

--- a/backup/bin/setup-barman
+++ b/backup/bin/setup-barman
@@ -118,13 +118,15 @@ def setup_cron(conf):
     print("Setting up cron jobs", flush=True)
     if len(conf) > 1:
         raise Exception("This needs work to support > 1 db")
+    # Runs update-nightly at 1am - this means it should be done by the
+    # time bb8 runs.
     cron = """
 * * * * * root barman cron
-0 6 * * * root update-nightly {}
+0 1 * * * root update-nightly {}
 """.lstrip().format(conf[0]["configuration_name"])
     with open("/etc/cron.d/barman", 'w') as f:
         f.write(cron)
-    print("Starting cron service")
+    print("Starting cron service", flush=True)
     subprocess.run(["service", "cron", "start"], check=True)
 
 

--- a/backup/bin/setup-barman
+++ b/backup/bin/setup-barman
@@ -116,7 +116,7 @@ def initial_backup(conf):
 
 def setup_cron(conf):
     print("Setting up cron jobs", flush=True)
-    if length(conf) > 1:
+    if len(conf) > 1:
         raise Exception("This needs work to support > 1 db")
     cron = """
 * * * * * root barman cron

--- a/backup/bin/setup-barman
+++ b/backup/bin/setup-barman
@@ -124,6 +124,8 @@ def setup_cron(conf):
 """.lstrip().format(conf[0]["configuration_name"])
     with open("/etc/cron.d/barman", 'w') as f:
         f.write(cron)
+    print("Starting cron service")
+    subprocess.run(["service", "cron", "start"], check=True)
 
 
 # This seems a bit flakey to archive but usually runs just fine the

--- a/backup/bin/setup-barman
+++ b/backup/bin/setup-barman
@@ -116,10 +116,12 @@ def initial_backup(conf):
 
 def setup_cron(conf):
     print("Setting up cron jobs", flush=True)
+    if length(conf) > 1:
+        raise Exception("This needs work to support > 1 db")
     cron = """
 * * * * * root barman cron
 0 6 * * * root update-nightly {}
-""".lstrip().format(conf["configuration_name"])
+""".lstrip().format(conf[0]["configuration_name"])
     with open("/etc/cron.d/barman", 'w') as f:
         f.write(cron)
 

--- a/backup/bin/setup-barman
+++ b/backup/bin/setup-barman
@@ -116,14 +116,8 @@ def initial_backup(conf):
 
 def setup_cron(conf):
     print("Setting up cron jobs", flush=True)
-    if len(conf) > 1:
-        raise Exception("This needs work to support > 1 db")
-    # Runs update-nightly at 1am - this means it should be done by the
-    # time bb8 runs.
-    cron = """
-* * * * * root barman cron
-0 1 * * * root update-nightly {}
-""".lstrip().format(conf[0]["configuration_name"])
+    # Once-per-minute cron job:
+    cron = "* * * * * root barman cron\n"
     with open("/etc/cron.d/barman", 'w') as f:
         f.write(cron)
     print("Starting cron service", flush=True)

--- a/backup/bin/update-nightly
+++ b/backup/bin/update-nightly
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 # The simplest way I can see to do this is via some bash options. I
 # tried some various 'find' incantations but none seem to behave

--- a/backup/bin/update-nightly
+++ b/backup/bin/update-nightly
@@ -28,4 +28,4 @@ barman recover $DATABASE latest $INCOMING_PATH
 rm -rf !($INCOMING_PATH)
 mv $INCOMING_PATH/* .
 rmdir $INCOMING_PATH
-echo $(date --rfc-3339=ns) > $INCOMING_PATH/.barman-last-restore
+echo $(date --rfc-3339=ns) > $NIGHTLY_PATH/.barman-last-restore

--- a/backup/bin/update-nightly
+++ b/backup/bin/update-nightly
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -ex
+
+# The simplest way I can see to do this is via some bash options. I
+# tried some various 'find' incantations but none seem to behave
+# terribly well.  These do:
+#
+#   - extglob: extension syntax for excluding files from a match (used in rm)
+#   - dotglob: include dot files in a * match
+#   - GLOBIGNORE: used to exclude '.' and '..' from a * match
+#
+# By doing all these operations on a single filesystem the 'mv'
+# command is instantaneous.  There is a race condition between the
+# 'rm' and the 'mv' though where there is an inconsistent filesystem.
+shopt -s extglob
+shopt -s dotglob
+GLOBIGNORE=".:.."
+
+DATABASE=$1
+NIGHTLY_PATH=$2
+
+INCOMING_PATH=.incoming
+
+cd $NIGHTLY_PATH
+
+barman recover montagu latest $INCOMING_PATH
+rm -rf !($INCOMING_PATH)
+mv $INCOMING_PATH/* .
+rmdir $INCOMING_PATH

--- a/backup/bin/update-nightly
+++ b/backup/bin/update-nightly
@@ -17,13 +17,15 @@ shopt -s dotglob
 GLOBIGNORE=".:.."
 
 DATABASE=$1
-NIGHTLY_PATH=$2
+
+NIGHTLY_PATH=/nightly
 
 INCOMING_PATH=.incoming
 
 cd $NIGHTLY_PATH
 
-barman recover montagu latest $INCOMING_PATH
+barman recover $DATABASE latest $INCOMING_PATH
 rm -rf !($INCOMING_PATH)
 mv $INCOMING_PATH/* .
 rmdir $INCOMING_PATH
+echo $(date --rfc-3339=ns) > $INCOMING_PATH/.barman-last-restore

--- a/backup/bin/update-nightly
+++ b/backup/bin/update-nightly
@@ -25,10 +25,12 @@ NIGHTLY_PATH=/nightly
 
 INCOMING_PATH=.incoming
 
+# Change directory here to simplify the path calculations later:
 cd $NIGHTLY_PATH
 
 barman recover $DATABASE latest $INCOMING_PATH
 rm -f $NIGHTLY_PATH/.barman-last-restore
+# This is the extglob syntax - read as "all paths except $INCOMING_PATH"
 rm -rf !($INCOMING_PATH)
 mv $INCOMING_PATH/* .
 rmdir $INCOMING_PATH

--- a/backup/bin/update-nightly
+++ b/backup/bin/update-nightly
@@ -12,6 +12,9 @@ set -e
 # By doing all these operations on a single filesystem the 'mv'
 # command is instantaneous.  There is a race condition between the
 # 'rm' and the 'mv' though where there is an inconsistent filesystem.
+#
+# The absence of the path .barman-last-restore means that the files
+# should not be used and a new backup should be requested.
 shopt -s extglob
 shopt -s dotglob
 GLOBIGNORE=".:.."
@@ -25,6 +28,7 @@ INCOMING_PATH=.incoming
 cd $NIGHTLY_PATH
 
 barman recover $DATABASE latest $INCOMING_PATH
+rm -f $NIGHTLY_PATH/.barman-last-restore
 rm -rf !($INCOMING_PATH)
 mv $INCOMING_PATH/* .
 rmdir $INCOMING_PATH

--- a/backup/demo_montagu.sh
+++ b/backup/demo_montagu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-./barman-montagu setup --image-tag=i1559 --pull localhost
+./barman-montagu setup --pull localhost
 ./barman-montagu recover
 
 docker run --rm -d \

--- a/backup/install
+++ b/backup/install
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+HERE=$(realpath $(dirname $0))
+NAME=barman-montagu
+DEST=/usr/local/bin/$NAME
+SRC=$HERE/$NAME
+
+if [[ -L $DEST && $(readlink -- $DEST) != $SRC ]]; then
+    rm -f $DEST
+fi
+
+if [ ! -L $DEST ]; then
+    echo "Creating link to $DEST to"
+    echo "    $SRC"
+    ln -s $SRC $DEST
+    echo "Done!"
+else
+    echo "Already installed!"
+fi

--- a/backup/requirements.txt
+++ b/backup/requirements.txt
@@ -1,4 +1,3 @@
 docker
 docopt
 hvac
-python-crontab

--- a/backup/testing/montagu-deploy.json
+++ b/backup/testing/montagu-deploy.json
@@ -1,0 +1,20 @@
+{
+    "clone_reports": false,
+    "instance_name": "teamcity",
+    "initial_data_source": "minimal",
+    "notify_channel": "",
+    "db_annex_type": "fake",
+    "open_browser": false,
+    "port": "8443",
+    "backup": false,
+    "hostname": "localhost",
+    "certificate": "self_signed",
+    "persist_data": false,
+    "vault_address": "https://support.montagu.dide.ic.ac.uk:8200",
+    "include_template_reports": false,
+    "require_clean_git": false,
+    "add_test_user": false,
+    "enable_db_replication": true,
+    "password_group": "production",
+    "bb8_backup": false
+}


### PR DESCRIPTION
This does a few different things together to make this work:

- the cron job is moved from the host machine to within the long-running container.  This simplifies deployment (and removal) but is a controversial decision (e.g. https://medium.com/@jonbaldie/how-to-run-cron-jobs-inside-docker-containers-26964315b582).  But now that we need two cron jobs I think this is better - and barman is weird enough anyway.
- the container gets another volume `/nightly` which will be the volume that can be used to get a recent backup for staging machines via bb8/starport
- there is a script `update-nightly` that tries to move into place the new backup as smoothly as possible.  The backup is done into a directory on the `/nightly` volume, then the previous restore is removed, then the new one is moved into place.  At the cost of twice the required storage this minimises the time we are exposed to an inconsistent filesystem.  The presence of the file `.barman-last-restore` indicates that the directory is good to use

After setting up in test mode, you should be able to monitor `/var/log/barman.log` which will tick over every minute

Merging #77 first will remove much of the noise from this PR