### PR TITLE
Increase default wait duration

### DIFF
--- a/bin/montagu-wait.sh
+++ b/bin/montagu-wait.sh
@@ -25,7 +25,7 @@ wait_for()
 
 # The variable expansion below is 15s by default, or the argument provided
 # to this script
-TIMEOUT="${1:-15}"
+TIMEOUT="${1:-30}"
 wait_for
 RESULT=$?
 if [[ $RESULT -ne 0 ]]; then


### PR DESCRIPTION
It frequently takes just over 15 seconds on my two work stations to get the database up - particularly the first time I run it after logging on. It might be nice to try and reduce the db startup time, but in the meantime this tiny PR will make my work less frustrating.