### PR TITLE
i2325: Script to update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dump/
 .idea
 demography
 **/__pycache__/*
+montagu-db-docs

--- a/scripts/update-docs
+++ b/scripts/update-docs
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT=$(dirname $(dirname $(realpath $0)))
+DB_SHA=$(git -C $ROOT rev-parse --short=7 HEAD)
+DB_BRANCH=$(git symbolic-ref --short HEAD)
+
+if [ $DB_BRANCH != "master" ]; then
+    echo "Not generating docs for branch $DB_BRANCH"
+    exit 0
+fi
+
+DB_DOCS_PATH=$ROOT/montagu-db-docs
+
+if [ -d $DB_DOCS_PATH ]; then
+    echo "Updating sources"
+    git -C $DB_DOCS_PATH fetch
+    git -C $DB_DOCS_PATH checkout master
+    git -C $DB_DOCS_PATH reset --hard origin/master
+else
+    git clone git@github.com:vimc/montagu-db-docs $DB_DOCS_PATH
+fi
+
+echo "Generating documentation"
+$DB_DOCS_PATH/generate.py $DB_SHA
+
+echo "Pushing to github"
+git -C $DB_DOCS_PATH push


### PR DESCRIPTION
I *think* this is enough to make it work, but it's hard to test for reasons

* we only want to generate docs when `montagu-db` is on master
* we want to do this on TC

TC is set up with ssh keys to allow pushing to montagu-db-docs and I've added a build step.  I toyed with a separate build configuration but because we don't have a snapshot dependency, TC was telling me that was a bad idea