### PR TITLE
make members of a group also have a global 'modeller' role

### DIFF
--- a/migrations/sql/V2018.12.13.1313__AddModellerRole.sql
+++ b/migrations/sql/V2018.12.13.1313__AddModellerRole.sql
@@ -1,0 +1,24 @@
+DO $$
+declare role_id int;
+declare member int;
+begin
+  SELECT id INTO member FROM role WHERE name = 'member';
+
+  -- create new globally scoped 'modeller' role
+  INSERT INTO role (name, scope_prefix, description)
+  VALUES ('modeller', NULL, 'Modeller')
+      RETURNING id
+        INTO role_id;
+
+  -- give modellers permission to read modelling groups
+  INSERT INTO role_permission values (role_id, 'modelling-groups.read');
+
+  -- make all members of a modelling group also 'modellers'
+  INSERT INTO user_group_role (user_group, role, scope_id)
+    SELECT user_group, role_id, ''
+    FROM user_group_role
+    WHERE role = member
+  ON CONFLICT DO NOTHING;
+
+end $$;
+


### PR DESCRIPTION
Modellers need to be able to call `GET /modelling-groups/` from the API to access the contribution portal. (Maybe we could re-write the portal to avoid this but we need an immediate fix.)

The existing role `member` is scoped to a group id, whereas the `GET /modelling-groups/` endpoint is locked down to only users with global group reading permission. So we need a new global role, `modeller`, which we can assign group reading permission to and then give to all members of a modelling group. 

Actually I think this makes sense anyway, since there are some global permissions we do want modellers to have (as opposed to just all users to have) and so far we have had no mechanism for this.