### PR TITLE
vimc-2901 Create dettl import log table

### DIFF
--- a/migrations/sql/V2019.05.03.0830__CreateDettlImportLog.sql
+++ b/migrations/sql/V2019.05.03.0830__CreateDettlImportLog.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+CREATE TABLE dettl_import_log (
+  name       TEXT PRIMARY KEY,
+  date       TIMESTAMP WITH TIME ZONE,
+  comment    TEXT,
+  git_user   TEXT,
+  git_email  TEXT,
+  git_branch TEXT,
+  git_hash   CHARACTER(40)
+);
+
+COMMIT;

--- a/migrations/sql/V2019.05.03.0830__CreateDettlImportLog.sql
+++ b/migrations/sql/V2019.05.03.0830__CreateDettlImportLog.sql
@@ -1,5 +1,3 @@
-BEGIN;
-
 CREATE TABLE dettl_import_log (
   name       TEXT PRIMARY KEY,
   date       TIMESTAMP WITH TIME ZONE,
@@ -9,5 +7,3 @@ CREATE TABLE dettl_import_log (
   git_branch TEXT,
   git_hash   CHARACTER(40)
 );
-
-COMMIT;


### PR DESCRIPTION
For `dettl` imports to be able to run an import log table must exist.

This will PR will
* Create the import log table as expected by https://github.com/vimc/dettl/blob/21ea478534edbef729da6b08c1ccf52e656a55b1/inst/sql/postgresql/create_log_table.sql

Note: We should wait for that PR to be merged into master before merging this to ensure there will be no changes to the structure of the expected table.