### PR TITLE
VIMC-3430: updates to annex deploy script and docs

### DIFF
--- a/annex/README.md
+++ b/annex/README.md
@@ -72,16 +72,6 @@ To stop the container and remove the data volume run
 ```
 ~/annex/annex/destroy.sh
 ```
-
-## Migrations
-
-After initial deployment, migrations can be handled from the main montagu
-deployment. When deploying in production mode it will perform any required
-migrations.
-
-Re-deployment should only be required when updating the underlying postgres
-container (e.g., security fixes).
-
 ## Testing
 
 There is a script for testing the idea in [`testing`](testing) - this can likely

--- a/annex/README.md
+++ b/annex/README.md
@@ -56,7 +56,6 @@ simpler set of scripts to the deploy (but similar).
 1. if a volume is not present one will be created
 1. start the db container and wait for it to allow connections
 1. if a volume _was_ created set the root password from the vault
-1. run the schema migrations
 
 ```
 ~/annex/annex/deploy.sh

--- a/annex/deploy.sh
+++ b/annex/deploy.sh
@@ -28,7 +28,7 @@ fi
 
 docker pull $ANNEX_IMAGE
 
-if docker inspect -f '{{.State.Running}}' $ANNEX_CONTAINER_NAME > /dev/null; then
+if docker inspect -f '{{.State.Running}}' $ANNEX_CONTAINER_NAME > /dev/null 2>&1; then
     echo "montagu db annex already exists: stopping"
     docker stop $ANNEX_CONTAINER_NAME
     docker rm $ANNEX_CONTAINER_NAME

--- a/annex/deploy.sh
+++ b/annex/deploy.sh
@@ -11,9 +11,20 @@ MONTAGU_REGISTRY=docker.montagu.dide.ic.ac.uk:5000
 
 ANNEX_IMAGE=${MONTAGU_REGISTRY}/${ANNEX_IMAGE_NAME}:${ANNEX_IMAGE_VERSION}
 
-export VAULT_ADDR=https://support.montagu.dide.ic.ac.uk:8200
-vault login -method=github
-ANNEX_VIMC_PASSWORD=$(vault read -field=password /secret/annex/users/vimc)
+if docker volume inspect $ANNEX_VOLUME_NAME > /dev/null 2>&1; then
+    echo "montagu db annex volume already exists"
+    INITIAL_DEPLOY=0
+else
+    echo "Fetching annex password"
+    export VAULT_ADDR=https://support.montagu.dide.ic.ac.uk:8200
+    vault login -method=github
+    ANNEX_VIMC_PASSWORD=$(vault read -field=password /secret/annex/users/vimc)
+
+    echo "Creating montagu db annex volume"
+    INITIAL_DEPLOY=1
+    docker volume create $ANNEX_VOLUME_NAME
+fi
+
 
 docker pull $ANNEX_IMAGE
 
@@ -21,15 +32,6 @@ if docker inspect -f '{{.State.Running}}' $ANNEX_CONTAINER_NAME > /dev/null; the
     echo "montagu db annex already exists: stopping"
     docker stop $ANNEX_CONTAINER_NAME
     docker rm $ANNEX_CONTAINER_NAME
-fi
-
-if docker volume inspect $ANNEX_VOLUME_NAME > /dev/null 2>&1; then
-    echo "montagu db annex volume already exists"
-    INITIAL_DEPLOY=0
-else
-    echo "Creating montagu db annex volume"
-    INITIAL_DEPLOY=1
-    docker volume create $ANNEX_VOLUME_NAME
 fi
 
 docker run -d \

--- a/annex/destroy.sh
+++ b/annex/destroy.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
-docker stop montagu_db_annex
-docker rm montagu_db_annex
-docker volume rm montagu_db_annex_volume
+echo "This will destroy all data in the annex, with no possibility to restore"
+read -r -p "Are you sure you want to delete the data? [yes/No] " response
+response=${response:l} #tolower
+if [[ $response = yes ]]; then
+    echo "Destroying annex"
+    docker stop montagu_db_annex
+    docker rm montagu_db_annex
+    docker volume rm montagu_db_annex_volume
+else
+    echo "Not deleting anything!"
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes some bitrot here:

* correct documentation
* safer destroy
* somewhat nicer deployment

I've confirmed that this is running the high-memory configuration and you can too if you deploy this locally (with `./deploy.sh`)

```
docker exec -it montagu_db_annex psql -U vimc -d montagu -c "SELECT name, setting, unit, min_val, max_val FROM pg_settings WHERE name = 'work_mem';"
```

There is still bits that could be removed:

* `restore_test` and `testing` seem probably so outdated that it is of only archaelogical interest?
* The README section on "Preparing" is probably removable.

