### PR TITLE
VIMC-3447 delete report related perms

### DIFF
--- a/migrations/sql/V2020.02.19.1135__RemoveReportPermissions.sql
+++ b/migrations/sql/V2020.02.19.1135__RemoveReportPermissions.sql
@@ -6,8 +6,10 @@ begin
     SELECT id INTO reviewer_id from role where name = 'reports.reviewer';
     DELETE FROM role_permission where permission = 'reports.read';
     DELETE FROM role_permission where permission = 'reports.review';
+    DELETE FROM role_permission where permission = 'reports.run';
     DELETE FROM permission where name = 'reports.read';
     DELETE FROM permission where name = 'reports.review';
+    DELETE FROM permission where name = 'reports.run';
     DELETE FROM user_group_role where role = reader_id;
     DELETE FROM user_group_role where role = reviewer_id;
     DELETE FROM role where name = 'reports.reader';

--- a/migrations/sql/V2020.02.19.1135__RemoveReportPermissions.sql
+++ b/migrations/sql/V2020.02.19.1135__RemoveReportPermissions.sql
@@ -1,0 +1,15 @@
+DO $$
+    declare reader_id int;
+    declare reviewer_id int;
+begin
+    SELECT id INTO reader_id from role where name = 'reports.reader';
+    SELECT id INTO reviewer_id from role where name = 'reports.reviewer';
+    DELETE FROM role_permission where permission = 'reports.read';
+    DELETE FROM role_permission where permission = 'reports.review';
+    DELETE FROM permission where name = 'reports.read';
+    DELETE FROM permission where name = 'reports.review';
+    DELETE FROM user_group_role where role = reader_id;
+    DELETE FROM user_group_role where role = reviewer_id;
+    DELETE FROM role where name = 'reports.reader';
+    DELETE FROM role where name = 'reports.reviewer';
+end $$;


### PR DESCRIPTION
These are now meaningless as orderly db handles its own roles and permissions.