### PR TITLE
Add scenario type table and setup linking to scenario_description

### DIFF
--- a/migrations/sql/V2020.06.10.1415__ScenarioType.sql
+++ b/migrations/sql/V2020.06.10.1415__ScenarioType.sql
@@ -4,52 +4,6 @@ CREATE TABLE scenario_type (
   PRIMARY KEY (id)
 );
 
--- create types
-INSERT INTO scenario_type (id, name)
-VALUES
-  ('novac', 'VIMC no-vaccination counterfactual scenario'),
-  ('default-high', 'VIMC default scenario with coverage 10% above forecast'),
-  ('default-low', 'VIMC default scenario with coverage 10% below forecast'),
-  ('default-high-transm', 'VIMC default scenario with high disease transmission'),
-  ('default-low-transm', 'VIMC default scenario with low disease transmission'),
-  ('default-best', 'VIMC default scenario with out-of-facility support'),
-  ('default-best-high-transm', 'VIMC default scenario with out-of-facility support and high disease transmission'),
-  ('default-best-low-transm', 'VIMC default scenario with out-of-facility support and low disease transmission'),
-  ('pre-gavi', 'VIMC scenarios without GAVI support'),
-  ('2010-levels', '*Pre VIMC scenario type. Information pending.*'),
-  ('default', 'VIMC default scenario'),
-  ('bestcase', 'BMGF bestcase scenario'),
-  ('stop', 'VIMC stop scenario'),
-  ('covid-scenario1', 'VPDS-COVID business as usual scenario 1'),
-  ('covid-scenario1-portnoy', 'VPDS-COVID business as usual scenario 1 - Portnoy CFRs'),
-  ('covid-scenario1-wolfson', 'VPDS-COVID business as usual scenario 1 - Wolfson CFRs'),
-  ('covid-scenario2', 'VPDS-COVID with disruption scenario 2'),
-  ('covid-scenario2-portnoy', 'VPDS-COVIDwith disruption scenario 2 - Portnoy CFRs'),
-  ('covid-scenario2-wolfson', 'VPDS-COVID with disruption scenario 2 - Wolfson CFRs'),
-  ('covid-scenario3', 'VPDS-COVID with disruption scenario 3'),
-  ('covid-scenario3-portnoy', 'VPDS-COVIDwith disruption scenario 3 - Portnoy CFRs'),
-  ('covid-scenario3-wolfson', 'VPDS-COVID with disruption scenario 3 - Wolfson CFRs'),
-  ('covid-scenario4', 'VPDS-COVID with disruption scenario 4'),
-  ('covid-scenario4-portnoy', 'VPDS-COVIDwith disruption scenario 4 - Portnoy CFRs'),
-  ('covid-scenario4-wolfson', 'VPDS-COVID with disruption scenario 4 - Wolfson CFRs'),
-  ('covid-scenario5', 'VPDS-COVID with disruption scenario 5'),
-  ('covid-scenario5-portnoy', 'VPDS-COVIDwith disruption scenario 5 - Portnoy CFRs'),
-  ('covid-scenario5-wolfson', 'VPDS-COVID with disruption scenario 5 - Wolfson CFRs'),
-  ('covid-scenario6', 'VPDS-COVID with disruption scenario 6'),
-  ('covid-scenario6-portnoy', 'VPDS-COVIDwith disruption scenario 6 - Portnoy CFRs'),
-  ('covid-scenario6-wolfson', 'VPDS-COVID with disruption scenario 6 - Wolfson CFRs'),
-  ('covid-scenario7', 'VPDS-COVID with disruption scenario 7'),
-  ('covid-scenario7-portnoy', 'VPDS-COVIDwith disruption scenario 7 - Portnoy CFRs'),
-  ('covid-scenario7-wolfson', 'VPDS-COVID with disruption scenario 7 - Wolfson CFRs'),
-  ('covid-scenario8', 'VPDS-COVID with disruption scenario 8'),
-  ('covid-scenario8-portnoy', 'VPDS-COVIDwith disruption scenario 8 - Portnoy CFRs'),
-  ('covid-scenario8-wolfson', 'VPDS-COVID with disruption scenario 8 - Wolfson CFRs'),
-  ('covid-scenario9', 'VPDS-COVID with disruption scenario 9'),
-  ('covid-scenario9-portnoy', 'VPDS-COVIDwith disruption scenario 9 - Portnoy CFRs'),
-  ('covid-scenario9-wolfson', 'VPDS-COVID with disruption scenario 9 - Wolfson CFRs'),
-  ('covid-scenario10-portnoy', 'VPDS-COVIDwith disruption scenario 10 - Portnoy CFRs'),
-  ('covid-scenario10-wolfson', 'VPDS-COVID with disruption scenario 10 - Wolfson CFRs');
-
 ALTER TABLE scenario_description
     ADD COLUMN scenario_type TEXT NULL;
 


### PR DESCRIPTION
This will

* Add a new table `scenario_type` with columns `id`, and `name` and the initial values for it (from Xiang)
* Add a column to `scenario_description` for `scenario_type` which links to the id of the `scenario_type` table

Only thoughts, maybe `id` and `description` are more appropriate for `scenario_type`. These are the column headers Xiang requested and match up with other tables e.g. `gavi_support_level` in usage.