### PR TITLE
vimc-4225 make network configurable in start script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,13 +3,13 @@
 ##
 ##   db - main db
 ##
-## On the network
+## On the provided network, defaulting to
 ##
 ##   db_nw
 set -e
 
 if (( "$#" < 1 || "$#" > 3 )); then
-    echo "Usage: start.sh <DB_VERSION> [<DB_PORT>]"
+    echo "Usage: start.sh <DB_VERSION> [<DB_PORT>] [<DB_NETWORK>]"
     echo "Starts the database using the specified image"
     echo "version. If DB_PORT is provided, exposes the main database on the "
     echo "host machine at that port."
@@ -19,6 +19,7 @@ fi
 set -ex
 DB_VERSION=$1
 DB_PORT=$2
+DB_NETWORK=$3
 
 PORT_MAPPING=
 if [[ ! -z $DB_PORT ]]; then
@@ -29,6 +30,11 @@ if [[ ! -z $PG_TEST_MODE ]]; then
     PG_CONFIG=/etc/montagu/postgresql.test.conf
 fi
 
+NETWORK=db_nw
+if [[ ! -z $DB_NETWORK ]]; then
+    NETWORK=$DB_NETWORK
+fi
+
 ORG=vimc
 
 DB_IMAGE=$ORG/montagu-db:$DB_VERSION
@@ -36,7 +42,6 @@ MIGRATE_IMAGE=$ORG/montagu-migrate:$DB_VERSION
 
 DB_CONTAINER=db
 DB_PORT=5432    # Exposed on host machine
-NETWORK=db_nw
 
 function cleanup {
     set +e

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
+
+DB_NETWORK=$1
+NETWORK=db_nw
+if [[ ! -z $DB_NETWORK ]]; then
+    NETWORK=$DB_NETWORK
+fi
+
 docker stop db
-docker network rm db_nw
+docker network rm $NETWORK


### PR DESCRIPTION
The start script is used in local development and testing. For the API build, it's useful to be able to specify the network that the container starts on, so that other dependencies can be run on the same network.

To test that this works, the following should all work; in the first 2 cases note from the output that the db container is running on `db_nw` and in the last case that it is running on network `test_nw`:
* `./scripts/start.sh master`
* `./scripts/start.sh master 5432`
* `./scripts/start.sh master 5432 test_nw`
