### PR TITLE
vimc-4363 add coverage_set_metadata table

### DIFF
--- a/migrations/sql/V2020.11.09.1222__AddCoverageSetMetadata.sql
+++ b/migrations/sql/V2020.11.09.1222__AddCoverageSetMetadata.sql
@@ -1,0 +1,15 @@
+CREATE TABLE coverage_set_metadata
+(
+    "id"          INTEGER   NOT NULL,
+    "uploaded_by" TEXT      NOT NULL,
+    "uploaded_on" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "filename"    TEXT      NULL,
+    "description" TEXT      NOT NULL,
+    PRIMARY KEY ("id")
+);
+
+ALTER TABLE "coverage_set_metadata"
+    ADD FOREIGN KEY ("uploaded_by") REFERENCES "app_user" ("username");
+
+ALTER TABLE "coverage_set_metadata"
+    ADD FOREIGN KEY ("id") REFERENCES "coverage_set" ("id");


### PR DESCRIPTION
adds table for storing metadata about coverage sets when uploaded via the portal