### PR TITLE
vimc-4363 allow for 1-many mapping of metadata to coverage set

### DIFF
--- a/migrations/sql/V2020.11.09.1222__AddCoverageSetMetadata.sql
+++ b/migrations/sql/V2020.11.09.1222__AddCoverageSetMetadata.sql
@@ -1,6 +1,6 @@
 CREATE TABLE coverage_set_metadata
 (
-    "id"          INTEGER   NOT NULL,
+    "id"          SERIAL,
     "uploaded_by" TEXT      NOT NULL,
     "uploaded_on" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "filename"    TEXT      NULL,
@@ -8,8 +8,17 @@ CREATE TABLE coverage_set_metadata
     PRIMARY KEY ("id")
 );
 
+CREATE TABLE coverage_set_coverage_set_metadata
+(
+    "coverage_set"          INTEGER   NOT NULL,
+    "coverage_set_metadata" INTEGER      NOT NULL
+);
+
 ALTER TABLE "coverage_set_metadata"
     ADD FOREIGN KEY ("uploaded_by") REFERENCES "app_user" ("username");
 
-ALTER TABLE "coverage_set_metadata"
-    ADD FOREIGN KEY ("id") REFERENCES "coverage_set" ("id");
+ALTER TABLE "coverage_set_coverage_set_metadata"
+    ADD FOREIGN KEY ("coverage_set") REFERENCES "coverage_set" ("id");
+
+ALTER TABLE "coverage_set_coverage_set_metadata"
+    ADD FOREIGN KEY ("coverage_set_metadata") REFERENCES "coverage_set_metadata" ("id");

--- a/migrations/sql/V2020.11.09.1222__AddCoverageSetMetadata.sql
+++ b/migrations/sql/V2020.11.09.1222__AddCoverageSetMetadata.sql
@@ -1,24 +1,12 @@
-CREATE TABLE coverage_set_metadata
+CREATE TABLE coverage_set_upload_metadata
 (
     "id"          SERIAL,
-    "uploaded_by" TEXT      NOT NULL,
+    "uploaded_by" TEXT      NOT NULL REFERENCES app_user (username),
     "uploaded_on" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "filename"    TEXT      NULL,
     "description" TEXT      NOT NULL,
     PRIMARY KEY ("id")
 );
 
-CREATE TABLE coverage_set_coverage_set_metadata
-(
-    "coverage_set"          INTEGER   NOT NULL,
-    "coverage_set_metadata" INTEGER      NOT NULL
-);
-
-ALTER TABLE "coverage_set_metadata"
-    ADD FOREIGN KEY ("uploaded_by") REFERENCES "app_user" ("username");
-
-ALTER TABLE "coverage_set_coverage_set_metadata"
-    ADD FOREIGN KEY ("coverage_set") REFERENCES "coverage_set" ("id");
-
-ALTER TABLE "coverage_set_coverage_set_metadata"
-    ADD FOREIGN KEY ("coverage_set_metadata") REFERENCES "coverage_set_metadata" ("id");
+ALTER TABLE coverage_set
+    ADD COLUMN coverage_set_upload_metadata INTEGER NULL REFERENCES coverage_set_upload_metadata (id);


### PR DESCRIPTION
Realised I got this wrong - each upload contains multiple coverage sets, so this should be a 1-many mapping.