### PR TITLE
vimc-4361 add subnational flag to coverage table

### DIFF
--- a/migrations/sql/V2020.11.10.1545__AddSubnationalFlagToCoverage.sql
+++ b/migrations/sql/V2020.11.10.1545__AddSubnationalFlagToCoverage.sql
@@ -1,0 +1,2 @@
+ALTER TABLE coverage
+    ADD COLUMN subnational BOOLEAN NULL;


### PR DESCRIPTION
Made it nullable because we don't want to wrongly infer this for existing data.