### PR TITLE
VIMC-4767 Add comments to responsibility sets

### DIFF
--- a/migrations/sql/V2021.07.05.1731__ResponsibilitySetComment.sql
+++ b/migrations/sql/V2021.07.05.1731__ResponsibilitySetComment.sql
@@ -1,0 +1,8 @@
+CREATE TABLE responsibility_set_comment
+(
+    id                 SERIAL PRIMARY KEY,
+    responsibility_set INTEGER   NOT NULL REFERENCES responsibility_set (id),
+    comment            TEXT      NOT NULL,
+    added_by           TEXT      NOT NULL REFERENCES app_user (username),
+    added_on           TIMESTAMP NOT NULL
+);


### PR DESCRIPTION
Create table for comments to be attached to responsibility sets, analogous to the recently-added [`responsibility_comment`](https://github.com/vimc/montagu-db/blob/master/migrations/sql/V2021.05.21.1323__ResponsibilityComment.sql). If the latter didn't exist then there could be an argument for a generic `comment` table, with `responsibility_comment` and `responsibility_set_comment` just acting as intermediaries, but this would complicate navigation through the database. Strong opinions either way welcome.