### PR TITLE
add `source_from` column to coverage table

### DIFF
--- a/migrations/sql/V2021.11.17.1525__CoverageSouceFrom.sql
+++ b/migrations/sql/V2021.11.17.1525__CoverageSouceFrom.sql
@@ -1,0 +1,3 @@
+ALTER TABLE coverage
+    ADD COLUMN source_from TEXT NULL;/* This field is to record coverage source if avaiable */
+


### PR DESCRIPTION
context: we are trying to add additional checks so that almost-duplicates coming from different information sources do not conflict with one another
changes: add a column to record the source of information for each vaccination activity