### PR TITLE
vimc-6273: add gavi74 column to country_metadata

### DIFF
--- a/migrations/sql/V2022.03.23.1702__AddGavi74.sql
+++ b/migrations/sql/V2022.03.23.1702__AddGavi74.sql
@@ -4,3 +4,4 @@ UPDATE country_metadata
 	SET gavi74 = FALSE;
 ALTER TABLE country_metadata 
 	ALTER COLUMN gavi74 SET NOT NULL;
+

--- a/migrations/sql/V2022.03.23.1702__AddGavi74.sql
+++ b/migrations/sql/V2022.03.23.1702__AddGavi74.sql
@@ -1,4 +1,6 @@
-ALTER TABLE country_metadata
-    ADD COLUMN gavi74 BOOLEAN default FALSE,
-    ALTER COLUMN gavi74 SET NOT NULL;
-
+ALTER TABLE country_metadata 
+	ADD COLUMN gavi74 BOOLEAN;
+UPDATE country_metadata 
+	SET gavi74 = FALSE;
+ALTER TABLE country_metadata 
+	ALTER COLUMN gavi74 SET NOT NULL;

--- a/migrations/sql/V2022.03.23.1702__AddGavi74.sql
+++ b/migrations/sql/V2022.03.23.1702__AddGavi74.sql
@@ -1,0 +1,4 @@
+ALTER TABLE country_metadata
+    ADD COLUMN gavi74 BOOLEAN default FALSE,
+    ALTER COLUMN gavi74 SET NOT NULL;
+

--- a/migrations/sql/V2022.03.23.1702__AssGavi74.sql
+++ b/migrations/sql/V2022.03.23.1702__AssGavi74.sql
@@ -1,3 +1,0 @@
-ALTER TABLE country_metadata
-    ADD COLUMN gavi74 BOOLEAN NULL;
-

--- a/migrations/sql/V2022.03.23.1702__AssGavi74.sql
+++ b/migrations/sql/V2022.03.23.1702__AssGavi74.sql
@@ -1,0 +1,3 @@
+ALTER TABLE country_metadata
+    ADD COLUMN gavi74 BOOLEAN NULL;
+


### PR DESCRIPTION
Youtrack:
https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-6273

Hi @kgaythorpe and @r-ash, here is a migration script adding column `gavi74` to table `country_metadata`. 